### PR TITLE
feat: Add S_BOX replacement constant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,44 @@ use std::vec::Vec;
 pub struct DecryptedState;
 pub struct EncryptedState;
 
+///
+/// AESBlock is a struct that represents a single 16 byte block of data. 
+/// It can be used to encrypt or decrypt the data based on the state the 
+/// struct was created.
+/// 
+/// The struct is generic over the state. The state can be either DecryptedState
+/// or EncryptedState. This is to ensure that the data is not encrypted or decrypted twice.
+/// 
+/// The struct contains a grid of 16 bytes. This grid is considered to be a 4x4 grid with
+/// row-major order. This means that the first 4 bytes are the first row, the next 4 bytes
+/// are the second row and so on.
+///  
 pub struct AESBlock<State = DecryptedState> {
     grid: Vec<u8>,
     state: std::marker::PhantomData<State>
 }
 
+///
+/// Implementation of the decrypted AESBlock struct.
+///
 impl AESBlock<DecryptedState> {
+
+    const S_BOX: [&'static u8; 256] = [ &0x63,&0x7c,&0x77,&0x7b,&0xf2,&0x6b,&0x6f,&0xc5,&0x30,&0x01,&0x67,&0x2b,&0xfe,&0xd7,&0xab,&0x76,
+                                        &0xca,&0x82,&0xc9,&0x7d,&0xfa,&0x59,&0x47,&0xf0,&0xad,&0xd4,&0xa2,&0xaf,&0x9c,&0xa4,&0x72,&0xc0,
+                                        &0xb7,&0xfd,&0x93,&0x26,&0x36,&0x3f,&0xf7,&0xcc,&0x34,&0xa5,&0xe5,&0xf1,&0x71,&0xd8,&0x31,&0x15,
+                                        &0x04,&0xc7,&0x23,&0xc3,&0x18,&0x96,&0x05,&0x9a,&0x07,&0x12,&0x80,&0xe2,&0xeb,&0x27,&0xb2,&0x75,
+                                        &0x09,&0x83,&0x2c,&0x1a,&0x1b,&0x6e,&0x5a,&0xa0,&0x52,&0x3b,&0xd6,&0xb3,&0x29,&0xe3,&0x2f,&0x84,
+                                        &0x53,&0xd1,&0x00,&0xed,&0x20,&0xfc,&0xb1,&0x5b,&0x6a,&0xcb,&0xbe,&0x39,&0x4a,&0x4c,&0x58,&0xcf,
+                                        &0xd0,&0xef,&0xaa,&0xfb,&0x43,&0x4d,&0x33,&0x85,&0x45,&0xf9,&0x02,&0x7f,&0x50,&0x3c,&0x9f,&0xa8,
+                                        &0x51,&0xa3,&0x40,&0x8f,&0x92,&0x9d,&0x38,&0xf5,&0xbc,&0xb6,&0xda,&0x21,&0x10,&0xff,&0xf3,&0xd2,
+                                        &0xcd,&0x0c,&0x13,&0xec,&0x5f,&0x97,&0x44,&0x17,&0xc4,&0xa7,&0x7e,&0x3d,&0x64,&0x5d,&0x19,&0x73,
+                                        &0x60,&0x81,&0x4f,&0xdc,&0x22,&0x2a,&0x90,&0x88,&0x46,&0xee,&0xb8,&0x14,&0xde,&0x5e,&0x0b,&0xdb,
+                                        &0xe0,&0x32,&0x3a,&0x0a,&0x49,&0x06,&0x24,&0x5c,&0xc2,&0xd3,&0xac,&0x62,&0x91,&0x95,&0xe4,&0x79,
+                                        &0xe7,&0xc8,&0x37,&0x6d,&0x8d,&0xd5,&0x4e,&0xa9,&0x6c,&0x56,&0xf4,&0xea,&0x65,&0x7a,&0xae,&0x08,
+                                        &0xba,&0x78,&0x25,&0x2e,&0x1c,&0xa6,&0xb4,&0xc6,&0xe8,&0xdd,&0x74,&0x1f,&0x4b,&0xbd,&0x8b,&0x8a,
+                                        &0x70,&0x3e,&0xb5,&0x66,&0x48,&0x03,&0xf6,&0x0e,&0x61,&0x35,&0x57,&0xb9,&0x86,&0xc1,&0x1d,&0x9e,
+                                        &0xe1,&0xf8,&0x98,&0x11,&0x69,&0xd9,&0x8e,&0x94,&0x9b,&0x1e,&0x87,&0xe9,&0xce,&0x55,&0x28,&0xdf,
+                                        &0x8c,&0xa1,&0x89,&0x0d,&0xbf,&0xe6,&0x42,&0x68,&0x41,&0x99,&0x2d,&0x0f,&0xb0,&0x54,&0xbb,&0x16];
 
     pub fn new(data: Vec<u8>) -> AESBlock<DecryptedState> {
         AESBlock {
@@ -17,10 +49,18 @@ impl AESBlock<DecryptedState> {
         }
     }
     
-    pub fn encrypt(&self, roundkeys: &Vec<Vec<u8>>, s_box: &[u8]) -> AESBlock<EncryptedState> {
+
+    ///
+    /// Full encryption of a single 16 byte block.
+    /// 
+    /// roundkeys: A vector of 11, 13 or 15 roundkeys. Each roundkey is a vector of 16 bytes.
+    /// 
+    /// result: A vector of 16 bytes encrypted.
+    /// 
+    pub fn encrypt(&self, roundkeys: &Vec<Vec<u8>>) -> AESBlock<EncryptedState> {
         let mut result = self.add_roundkey(&self.grid, &roundkeys[0]);
         for (idx, _) in roundkeys.iter().skip(1).enumerate() {
-            result = self.sub_bytes(&result, s_box);
+            result = self.sub_bytes(&result);
             result = self.shift_grid(&result);
             result = if idx != roundkeys.len() - 1 {
                 self.mix_columns(&result)
@@ -102,6 +142,17 @@ impl AESBlock<DecryptedState> {
         result
     }
 
+    ///
+    /// Mixes the columns of the grid by using the  Rijndael MixColumns
+    /// algorithm. Description of the algorithm can be found here:
+    /// https://en.wikipedia.org/wiki/Rijndael_MixColumns.
+    /// 
+    /// data: A vector of 16 bytes. These are considered to be in
+    ///      pattern of a 4x4 grid with row-major order.
+    /// 
+    /// result: A vector of 16 bytes. These are considered to be in
+    ///     pattern of a 4x4 grid with row-major order.
+    /// 
     fn mix_columns(&self, data: &[u8]) -> Vec<u8> {        
         let col1: Vec<u8> = self.mix_column(&data.iter().step_by(4).collect());
         let col2: Vec<u8> = self.mix_column(&data.iter().skip(1).step_by(4).collect());
@@ -110,8 +161,27 @@ impl AESBlock<DecryptedState> {
         vec![col1[0], col2[0], col3[0], col4[0], col1[1], col2[1], col3[1], col4[1], col1[2], col2[2], col3[2], col4[2], col1[3], col2[3], col3[3], col4[3]]
     }
 
+    ///
+    /// Substitutes each byte in the data with the corresponding byte in the s_box.
+    /// 
+    /// data: A vector of bytes to be exchanged..
+    /// s_box: A vector of bytes containg the substitution values.
+    /// 
+    /// result: A vector of bytes with the substituted values.
+    /// 
+    fn sub_bytes(&self, data: &[u8]) -> Vec<u8> {
+        let mut result = vec![0; data.len()];
+        for (idx, value) in data.iter().enumerate() {
+            result[idx] = *AESBlock::S_BOX[*value as usize];            
+        }
+        result
+    }
+
 }
 
+///
+/// Implementation of the encrypted AESBlock struct.
+///
 impl AESBlock<EncryptedState> {
 
     pub fn new(data: Vec<u8>) -> AESBlock<EncryptedState> {
@@ -131,23 +201,10 @@ impl AESBlock<EncryptedState> {
 
 }
 
+///
+/// Implementation of the encrypted AESBlock struct.
+///
 impl AESBlock {
-
-    ///
-    /// Substitutes each byte in the data with the corresponding byte in the s_box.
-    /// 
-    /// data: A vector of bytes to be exchanged..
-    /// s_box: A vector of bytes containg the substitution values.
-    /// 
-    /// result: A vector of bytes with the substituted values.
-    /// 
-    fn sub_bytes(&self, data: &[u8], s_box: &[u8]) -> Vec<u8> {
-        let mut result = vec![0; data.len()];
-        for (idx, value) in data.iter().enumerate() {
-            result[idx] = s_box[*value as usize];
-        }
-        result
-    }
 
     ///
     /// Adds the roundkey to the data.
@@ -277,14 +334,22 @@ mod tests {
     #[test]
     fn test_encrypt() {
         let aes_block: AESBlock = AESBlock::<DecryptedState>::new(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-        let roundkeys: Vec<Vec<u8>> = vec![vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4], vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4], vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4]];
-        let result: AESBlock<EncryptedState> = aes_block.encrypt(&roundkeys, &gen_s_box());
+        let roundkeys: Vec<Vec<u8>> = vec![
+            vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4], 
+            vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4], 
+            vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4], 
+            vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4], 
+            vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4],
+            vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4], 
+            vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4], 
+            vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4], 
+            vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4], 
+            vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4],
+            vec![0, 2, 4, 8, 12, 1, 3, 5, 7, 9, 11, 13, 15, 2, 3, 4]
+            ];
+        let result: AESBlock<EncryptedState> = aes_block.encrypt(&roundkeys);
+        let expected_result: Vec<u8> = vec![128, 249, 176, 188, 201, 213, 195, 110, 192, 161, 230, 165, 31, 182, 33, 44];
+        assert_eq!(expected_result, result.grid);
     }
-
-
-    fn gen_s_box() -> Vec<u8> {
-        (0..255).collect()
-    }
-
 
 }


### PR DESCRIPTION
The code will now use the S_BOX constant for replacement instead of sending it as input. Since this always remains the same it is better to have it as a constant.

Breaking changes: None

Resolves: #3